### PR TITLE
Implement reflection board

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import Summary from './pages/Summary';
 import Charters from './pages/Charters';
 import Reflections from './pages/Reflections';
 import TodoCreation from './pages/TodoCreation';
+import PostCreation from './pages/PostCreation';
 
 function App() {
     return (
@@ -18,6 +19,7 @@ function App() {
                 <Route path="/summary" component={Summary} />
                 <Route path="/charters" component={Charters} />
                 <Route path="/reflections" component={Reflections} />
+                <Route path="/tasks/create-post" component={PostCreation} />
             </Switch>
         </Router>
     );

--- a/src/components/charters-page/CharterItem.js
+++ b/src/components/charters-page/CharterItem.js
@@ -4,7 +4,7 @@ import Box from '@mui/material/Box';
 // title: fontcolor varies when `charters` or `charter templates`
 // content: line breaks, calendar view, placeholder
 
-export default function CharterItem() {
+export default function CharterItem({ item }) {
     return (
         <div>
             <Box
@@ -20,13 +20,8 @@ export default function CharterItem() {
                     mb: 2
                 }}
             >
-                <h2>charter item</h2>
-                <p>
-                    some agreements here some agreements here some agreements here some agreement here <br />
-                    some agreements here some agreements here some agreements here some agreement here <br />
-                    some agreements here some agreements here <br />
-                    some agreements here some agreements here <br />
-                </p>
+                <h2>{item.title}</h2>
+                <p>{item.content}</p>
             </Box>
         </div>
     );

--- a/src/components/charters-page/CharterList.js
+++ b/src/components/charters-page/CharterList.js
@@ -4,10 +4,10 @@ import Box from '@mui/material/Box';
 
 // container with purple bg
 // a list of charter items
-export default function CharterList() {
+export default function CharterList({ name, data_list }) {
     return (
         <div>
-            <h1>Charters list</h1>
+            <h1>{name}</h1>
             <Box
                 sx={{
                     bgcolor: 'primary.main',
@@ -19,7 +19,9 @@ export default function CharterList() {
                     pr: 3
                 }}
             >
-                <CharterItem />
+                {
+                    data_list.map(item => <CharterItem item={item} />)
+                }
             </Box>
         </div>
     )

--- a/src/components/charters-page/CharterList.js
+++ b/src/components/charters-page/CharterList.js
@@ -13,30 +13,12 @@ export default function CharterList() {
                     bgcolor: 'primary.main',
                     borderTopLeftRadius: 15,
                     borderTopRightRadius: 15,
-                    height: 1,
+                    minHeight: "100vh",
                     pt: 2,
                     pl: 3,
                     pr: 3
                 }}
             >
-
-                <CharterItem />
-                <CharterItem />
-                <CharterItem />
-                <CharterItem />
-                <CharterItem />
-                <CharterItem />
-                <CharterItem />
-                <CharterItem />
-                <CharterItem />
-                <CharterItem />
-                <CharterItem />
-                <CharterItem />
-                <CharterItem />
-                <CharterItem />
-                <CharterItem />
-                <CharterItem />
-                <CharterItem />
                 <CharterItem />
             </Box>
         </div>

--- a/src/pages/PostCreation.js
+++ b/src/pages/PostCreation.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useHistory } from 'react-router-dom';
+import IconButton from '@mui/material/IconButton';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import TextField from '@mui/material/TextField';
+
+export default function PostCreation({ test }) {
+    const history = useHistory()
+
+    const goBack = () => {
+        history.goBack()
+    }
+
+    console.log("prop:", test);
+
+    return (
+        <div>
+            <IconButton
+                size="large"
+                edge="start"
+                color="inherit"
+                aria-label="home"
+                sx={{ mr: 2, color: "primary.main", left: 22, top: 23 }}
+                onClick={goBack}
+            >
+                <ArrowBackIcon sx={{ fontSize: 35 }} />
+            </IconButton>
+            <h1>make a post here</h1>
+            <TextField
+                id="outlined-multiline-static"
+                label="Multiline"
+                multiline
+                rows={4}
+                defaultValue="Default Value"
+            />
+        </div>
+    )
+}

--- a/src/pages/PostCreation.js
+++ b/src/pages/PostCreation.js
@@ -3,15 +3,31 @@ import { useHistory } from 'react-router-dom';
 import IconButton from '@mui/material/IconButton';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
 
-export default function PostCreation({ test }) {
+export default function PostCreation() {
     const history = useHistory()
 
     const goBack = () => {
         history.goBack()
     }
 
-    console.log("prop:", test);
+    const [title, setTitle] = React.useState("");
+    const [content, setContent] = React.useState("");
+    const [date, setDate] = React.useState(new Date());
+
+    const postData = () => {
+        setDate(new Date());
+        const post = { title, content, date };
+        fetch("http://localhost:3000/api/board/621d26f81a997588eb8b7979/1", {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(post)
+        })
+    }
 
     return (
         <div>
@@ -26,13 +42,26 @@ export default function PostCreation({ test }) {
                 <ArrowBackIcon sx={{ fontSize: 35 }} />
             </IconButton>
             <h1>make a post here</h1>
-            <TextField
-                id="outlined-multiline-static"
-                label="Multiline"
-                multiline
-                rows={4}
-                defaultValue="Default Value"
-            />
+            <Stack>
+                <TextField
+                    placeholder="title"
+                    value={title}
+                    sx={{ fontSize: 24, maxWidth: 300, p: 1, pb: 3 }}
+                    onChange={event => setTitle(event.target.value)}
+                />
+
+                <TextField
+                    id="outlined-multiline-static"
+                    label="Enter your reflection"
+                    multiline
+                    rows={4}
+                    sx={{ p: 1 }}
+                    value={content}
+                    onChange={event => setContent(event.target.value)}
+                />
+
+                <Button variant="contained" onClick={e => postData()}>Post</Button>
+            </Stack>
         </div>
     )
 }

--- a/src/pages/PostCreation.js
+++ b/src/pages/PostCreation.js
@@ -60,7 +60,7 @@ export default function PostCreation() {
                     onChange={event => setContent(event.target.value)}
                 />
 
-                <Button variant="contained" onClick={e => postData()}>Post</Button>
+                <Button href="/reflections" variant="contained" onClick={e => postData()}>Post</Button>
             </Stack>
         </div>
     )

--- a/src/pages/Reflections.js
+++ b/src/pages/Reflections.js
@@ -1,12 +1,28 @@
 import React from 'react';
 import HeaderBar from '../components/nav/HeaderBar';
 import BottomNavBar from '../components/nav/BottomNavbar';
+import AddButton from '../components/common/AddButton';
+import CharterList from '../components/charters-page/CharterList';
 
 export default function Reflections() {
+    const [posts, setPosts] = React.useState([]);
+    // React.useEffect(() => {
+    // fetch posts from api
+    // setPosts(api_res)
+    fetch("http://localhost:3000/api/board/621d26f81a997588eb8b7979/1", { mode: "no-cors" })
+        .then(res => res.json())
+        .then(data => setPosts(data))
+        .catch(error => console.log("error:", error));
+
+    console.log("posts:", posts);
+    const postPath = "/tasks/create-post";
+
     return (
         <div>
             <HeaderBar />
             Reflections page
+            <AddButton path={postPath} />
+            <CharterList />
             <BottomNavBar />
         </div>
     )

--- a/src/pages/Reflections.js
+++ b/src/pages/Reflections.js
@@ -5,25 +5,40 @@ import AddButton from '../components/common/AddButton';
 import CharterList from '../components/charters-page/CharterList';
 
 export default function Reflections() {
+    const [isLoaded, setIsLoaded] = React.useState(false);
     const [posts, setPosts] = React.useState([]);
-    // React.useEffect(() => {
-    // fetch posts from api
-    // setPosts(api_res)
-    fetch("http://localhost:3000/api/board/621d26f81a997588eb8b7979/1", { mode: "no-cors" })
-        .then(res => res.json())
-        .then(data => setPosts(data))
-        .catch(error => console.log("error:", error));
 
-    console.log("posts:", posts);
+    const loadPosts = async () => {
+        await fetch("http://localhost:3000/api/board/621d26f81a997588eb8b7979/1")
+            .then(res => res.json())
+            .then(receivedPosts => {
+                setPosts(receivedPosts);
+                setIsLoaded(true);
+            })
+            .catch(error => {
+                setIsLoaded(false);
+                console.log("load data error:", error);
+            })
+    }
+    React.useEffect(() => {
+        // fetch posts from api
+        loadPosts();
+    }, []);
+
+
     const postPath = "/tasks/create-post";
 
     return (
         <div>
-            <HeaderBar />
-            Reflections page
-            <AddButton path={postPath} />
-            <CharterList />
-            <BottomNavBar />
+            {!isLoaded && <p>Loading...</p>}
+            {isLoaded && (
+                <div>
+                    <HeaderBar screenname="Reflection" />
+                    <AddButton path={postPath} />
+                    <CharterList name="Reflection" data_list={posts} />
+                    <BottomNavBar />
+                </div>
+            )}
         </div>
     )
 }


### PR DESCRIPTION
Done
- Load reflection posts from locally running backend
- Send user posts to database
- Auto refresh and route to reflection board once post is sent
- Reuse charter's components

Next step
- Fix regression bug due to changes in CharterList and CharterItem (May rename both components as common)
- Display date on each post
- 3-dot option menu