### PR TITLE
Implement charter screen

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import Charters from './pages/Charters';
 import Reflections from './pages/Reflections';
 import TodoCreation from './pages/TodoCreation';
 import PostCreation from './pages/PostCreation';
+import CharterTemplate from './pages/CharterTemplate';
 
 function App() {
     return (
@@ -17,9 +18,10 @@ function App() {
                 <Route path="/tasks/create-todo" component={TodoCreation} />
                 <Route path="/chats" component={Chats} />
                 <Route path="/summary" component={Summary} />
-                <Route path="/charters" component={Charters} />
-                <Route path="/reflections" component={Reflections} />
-                <Route path="/tasks/create-post" component={PostCreation} />
+                <Route exact path="/charters" component={Charters} />
+                <Route path="/charters/charter-templates" component={CharterTemplate} />
+                <Route exact path="/reflections" component={Reflections} />
+                <Route path="/reflections/create-post" component={PostCreation} />
             </Switch>
         </Router>
     );

--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import Reflections from './pages/Reflections';
 import TodoCreation from './pages/TodoCreation';
 import PostCreation from './pages/PostCreation';
 import CharterTemplate from './pages/CharterTemplate';
+import CharterCreation from './pages/CharterCreation';
 
 function App() {
     return (
@@ -20,6 +21,7 @@ function App() {
                 <Route path="/summary" component={Summary} />
                 <Route exact path="/charters" component={Charters} />
                 <Route path="/charters/charter-templates" component={CharterTemplate} />
+                <Route path="/charters/create-charter" component={CharterCreation} />
                 <Route exact path="/reflections" component={Reflections} />
                 <Route path="/reflections/create-post" component={PostCreation} />
             </Switch>

--- a/src/components/charters-page/CharterItem.js
+++ b/src/components/charters-page/CharterItem.js
@@ -20,7 +20,7 @@ export default function CharterItem({ item }) {
                     mb: 2
                 }}
             >
-                <h2>{item.title}</h2>
+                <h2>{item.title || item.name}</h2>
                 <p>{item.content}</p>
             </Box>
         </div>

--- a/src/components/charters-page/CharterTemplateItem.js
+++ b/src/components/charters-page/CharterTemplateItem.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import { ButtonBase } from "@mui/material";
+import { Link, useLocation } from 'react-router-dom';
+
+export default function CharterTemplateItem({ item }) {
+    const charterCreatorPath = "/charters/create-charter";
+
+    const location = useLocation();
+    const { data } = location.state;
+    if (!item) {
+        item = data;
+        console.log("item", item);
+    }
+
+    return (
+        <ButtonBase
+            focusRipple
+            onClick={event => console.log("e", event.target.value)}
+        >
+            <Box
+                sx={{
+                    bgcolor: 'white',
+                    borderRadius: 8,
+                    minWidth: 'auto',
+                    minHeight: 196,
+                    pt: 0.5,
+                    pl: 4,
+                    pr: 4,
+                    pb: 0.5,
+                    mb: 2
+                }}
+            >
+                <h2>{item.title || item.name}</h2>
+                <p>{item.content}</p>
+                <Link to={{
+                    pathname: charterCreatorPath,
+                    state: {
+                        data: data
+                    },
+                }}>Use this template</Link>
+            </Box>
+        </ButtonBase>
+    );
+}

--- a/src/components/charters-page/CharterTemplateItem.js
+++ b/src/components/charters-page/CharterTemplateItem.js
@@ -6,17 +6,10 @@ import { Link, useLocation } from 'react-router-dom';
 export default function CharterTemplateItem({ item }) {
     const charterCreatorPath = "/charters/create-charter";
 
-    const location = useLocation();
-    const { data } = location.state;
-    if (!item) {
-        item = data;
-        console.log("item", item);
-    }
-
     return (
         <ButtonBase
             focusRipple
-            onClick={event => console.log("e", event.target.value)}
+        // onClick={event => console.log("e", event.target.value)}
         >
             <Box
                 sx={{
@@ -36,7 +29,7 @@ export default function CharterTemplateItem({ item }) {
                 <Link to={{
                     pathname: charterCreatorPath,
                     state: {
-                        data: data
+                        data: item
                     },
                 }}>Use this template</Link>
             </Box>

--- a/src/components/charters-page/CharterTemplateList.js
+++ b/src/components/charters-page/CharterTemplateList.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import CharterTemplateItem from './CharterTemplateItem';
 import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
 
 // container with purple bg
 // a list of charter items
@@ -19,9 +20,11 @@ export default function CharterTemplateList({ name, data_list }) {
                     pr: 3
                 }}
             >
-                {
-                    data_list.map((item) => <CharterTemplateItem item={item} />)
-                }
+                <Stack>
+                    {
+                        data_list.map((item) => <CharterTemplateItem item={item} />)
+                    }
+                </Stack>
             </Box>
         </div>
     )

--- a/src/components/charters-page/CharterTemplateList.js
+++ b/src/components/charters-page/CharterTemplateList.js
@@ -20,7 +20,7 @@ export default function CharterTemplateList({ name, data_list }) {
                 }}
             >
                 {
-                    data_list.map(item => <CharterTemplateItem item={item} />)
+                    data_list.map((item) => <CharterTemplateItem item={item} />)
                 }
             </Box>
         </div>

--- a/src/components/charters-page/CharterTemplateList.js
+++ b/src/components/charters-page/CharterTemplateList.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import CharterTemplateItem from './CharterTemplateItem';
+import Box from '@mui/material/Box';
+
+// container with purple bg
+// a list of charter items
+export default function CharterTemplateList({ name, data_list }) {
+    return (
+        <div>
+            <h1>{name}</h1>
+            <Box
+                sx={{
+                    bgcolor: 'primary.main',
+                    borderTopLeftRadius: 15,
+                    borderTopRightRadius: 15,
+                    minHeight: "100vh",
+                    pt: 2,
+                    pl: 3,
+                    pr: 3
+                }}
+            >
+                {
+                    data_list.map(item => <CharterTemplateItem item={item} />)
+                }
+            </Box>
+        </div>
+    )
+}

--- a/src/pages/CharterCreation.js
+++ b/src/pages/CharterCreation.js
@@ -15,14 +15,12 @@ export default function CharterCreation() {
 
     const location = useLocation();
     const { data } = location.state;
-    console.log("data:", data);
 
     const [name, setName] = React.useState("");
     const [content, setContent] = React.useState("");
 
     const postData = () => {
         const post = { name, content };
-        // TODO: change url
         fetch("http://localhost:3000/api/charters/621d26f81a997588eb8b7979/1", {
             method: 'POST',
             headers: {
@@ -47,17 +45,16 @@ export default function CharterCreation() {
 
             <Stack>
                 <TextField
-                    placeholder={data[0].name}
+                    placeholder={data.name}
                     value={name}
                     sx={{ fontSize: 24, maxWidth: 300, p: 1, pb: 3 }}
                     onChange={event => setName(event.target.value)}
                 />
-
                 <TextField
                     id="outlined-multiline-static"
-                    placeholder={data[0].content}
+                    placeholder={data.content + "\n\n" + data.example}
                     multiline
-                    rows={4}
+                    rows={8}
                     sx={{ p: 1 }}
                     value={content}
                     onChange={event => setContent(event.target.value)}

--- a/src/pages/CharterCreation.js
+++ b/src/pages/CharterCreation.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
+import IconButton from '@mui/material/IconButton';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+
+export default function CharterCreation() {
+    const history = useHistory()
+
+    const goBack = () => {
+        history.goBack()
+    }
+
+    const location = useLocation();
+    const { data } = location.state;
+    console.log("data:", data);
+
+    const [title, setTitle] = React.useState("");
+    const [content, setContent] = React.useState("");
+    const [date, setDate] = React.useState(new Date());
+
+    const postData = () => {
+        setDate(new Date());
+        const post = { title, content, date };
+        // TODO: change url
+        fetch("http://localhost:3000/api/board/621d26f81a997588eb8b7979/1", {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(post)
+        })
+    }
+
+    return (
+        <div>
+            <IconButton
+                size="large"
+                edge="start"
+                color="inherit"
+                aria-label="home"
+                sx={{ mr: 2, color: "primary.main", left: 22, top: 23 }}
+                onClick={goBack}
+            >
+                <ArrowBackIcon sx={{ fontSize: 35 }} />
+            </IconButton>
+            <h1>make a post here</h1>
+            <Stack>
+                <TextField
+                    placeholder={data[0].name}
+                    value={title}
+                    sx={{ fontSize: 24, maxWidth: 300, p: 1, pb: 3 }}
+                    onChange={event => setTitle(event.target.value)}
+                />
+
+                <TextField
+                    id="outlined-multiline-static"
+                    placeholder={data[0].content}
+                    multiline
+                    rows={4}
+                    sx={{ p: 1 }}
+                    value={content}
+                    onChange={event => setContent(event.target.value)}
+                />
+
+                <Button href="/reflections" variant="contained" onClick={e => postData()}>Post</Button>
+            </Stack>
+        </div>
+    )
+}

--- a/src/pages/CharterCreation.js
+++ b/src/pages/CharterCreation.js
@@ -17,15 +17,13 @@ export default function CharterCreation() {
     const { data } = location.state;
     console.log("data:", data);
 
-    const [title, setTitle] = React.useState("");
+    const [name, setName] = React.useState("");
     const [content, setContent] = React.useState("");
-    const [date, setDate] = React.useState(new Date());
 
     const postData = () => {
-        setDate(new Date());
-        const post = { title, content, date };
+        const post = { name, content };
         // TODO: change url
-        fetch("http://localhost:3000/api/board/621d26f81a997588eb8b7979/1", {
+        fetch("http://localhost:3000/api/charters/621d26f81a997588eb8b7979/1", {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'
@@ -46,13 +44,13 @@ export default function CharterCreation() {
             >
                 <ArrowBackIcon sx={{ fontSize: 35 }} />
             </IconButton>
-            <h1>make a post here</h1>
+
             <Stack>
                 <TextField
                     placeholder={data[0].name}
-                    value={title}
+                    value={name}
                     sx={{ fontSize: 24, maxWidth: 300, p: 1, pb: 3 }}
-                    onChange={event => setTitle(event.target.value)}
+                    onChange={event => setName(event.target.value)}
                 />
 
                 <TextField
@@ -65,7 +63,7 @@ export default function CharterCreation() {
                     onChange={event => setContent(event.target.value)}
                 />
 
-                <Button href="/reflections" variant="contained" onClick={e => postData()}>Post</Button>
+                <Button href="/charters" variant="contained" onClick={e => postData()}>Post</Button>
             </Stack>
         </div>
     )

--- a/src/pages/CharterTemplate.js
+++ b/src/pages/CharterTemplate.js
@@ -14,7 +14,6 @@ export default function CharterTemplate({ data_list }) {
     const { data } = location.state;
     if (!data_list) {
         data_list = data;
-        console.log("data_list", data_list);
     }
 
     React.useEffect(() => {

--- a/src/pages/CharterTemplate.js
+++ b/src/pages/CharterTemplate.js
@@ -1,0 +1,67 @@
+import React from 'react';
+// import HeaderBar from '../components/nav/HeaderBar';
+import IconButton from '@mui/material/IconButton';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import BottomNavBar from '../components/nav/BottomNavbar';
+import CharterList from '../components/charters-page/CharterList';
+import { useHistory, useLocation } from 'react-router-dom';
+
+
+export default function CharterTemplate({ data_list }) {
+    // const [isLoaded, setIsLoaded] = React.useState(false);
+    const [charters, setCharters] = React.useState([]);
+
+    // const loadCharters = async () => {
+    //     await fetch("http://localhost:3000/api/charters/621d26f81a997588eb8b7979/1")
+    //         .then(res => res.json())
+    //         .then(receivedCharters => {
+    //             setCharters(receivedCharters);
+    //             setIsLoaded(true);
+    //         })
+    //         .catch(error => {
+    //             setIsLoaded(false);
+    //             console.log("load data error:", error);
+    //         })
+    // }
+
+    const location = useLocation();
+    const { data } = location.state;
+    if (!data_list) {
+        data_list = data;
+        console.log("data_list", data_list);
+    }
+
+    React.useEffect(() => {
+        // loadCharters();
+        setCharters(data_list);
+    }, []);
+
+    const history = useHistory()
+    const goBack = () => {
+        history.goBack()
+    }
+    // console.log("data: ", data_list);
+    return (
+        // <div>
+        //     {!isLoaded && <p>Loading...</p>}
+        //     {isLoaded && (
+        <div>
+            {/* TODO: add home/arrow switch in HeaderBar */}
+            {/* <HeaderBar screenname="Charter Template"/> */}
+            <IconButton
+                size="large"
+                edge="start"
+                color="inherit"
+                aria-label="home"
+                sx={{ mr: 2, color: "primary.main", left: 22, top: 23 }}
+                onClick={goBack}
+            >
+                <ArrowBackIcon sx={{ fontSize: 35 }} />
+            </IconButton>
+            <CharterList name="charter templates" data_list={charters} />
+            <BottomNavBar />
+        </div>
+        //     )}
+        // </div>
+    )
+}

--- a/src/pages/CharterTemplate.js
+++ b/src/pages/CharterTemplate.js
@@ -3,26 +3,12 @@ import React from 'react';
 import IconButton from '@mui/material/IconButton';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import BottomNavBar from '../components/nav/BottomNavbar';
-import CharterList from '../components/charters-page/CharterList';
+import CharterTemplateList from '../components/charters-page/CharterTemplateList';
 import { useHistory, useLocation } from 'react-router-dom';
 
 
 export default function CharterTemplate({ data_list }) {
-    // const [isLoaded, setIsLoaded] = React.useState(false);
     const [charters, setCharters] = React.useState([]);
-
-    // const loadCharters = async () => {
-    //     await fetch("http://localhost:3000/api/charters/621d26f81a997588eb8b7979/1")
-    //         .then(res => res.json())
-    //         .then(receivedCharters => {
-    //             setCharters(receivedCharters);
-    //             setIsLoaded(true);
-    //         })
-    //         .catch(error => {
-    //             setIsLoaded(false);
-    //             console.log("load data error:", error);
-    //         })
-    // }
 
     const location = useLocation();
     const { data } = location.state;
@@ -32,7 +18,6 @@ export default function CharterTemplate({ data_list }) {
     }
 
     React.useEffect(() => {
-        // loadCharters();
         setCharters(data_list);
     }, []);
 
@@ -40,11 +25,8 @@ export default function CharterTemplate({ data_list }) {
     const goBack = () => {
         history.goBack()
     }
-    // console.log("data: ", data_list);
+
     return (
-        // <div>
-        //     {!isLoaded && <p>Loading...</p>}
-        //     {isLoaded && (
         <div>
             {/* TODO: add home/arrow switch in HeaderBar */}
             {/* <HeaderBar screenname="Charter Template"/> */}
@@ -58,10 +40,8 @@ export default function CharterTemplate({ data_list }) {
             >
                 <ArrowBackIcon sx={{ fontSize: 35 }} />
             </IconButton>
-            <CharterList name="charter templates" data_list={charters} />
+            <CharterTemplateList name="charter templates" data_list={charters} />
             <BottomNavBar />
         </div>
-        //     )}
-        // </div>
     )
 }

--- a/src/pages/Charters.js
+++ b/src/pages/Charters.js
@@ -2,6 +2,8 @@ import React from 'react';
 import HeaderBar from '../components/nav/HeaderBar';
 import BottomNavBar from '../components/nav/BottomNavbar';
 import CharterList from '../components/charters-page/CharterList';
+import AddButton from '../components/common/AddButton';
+import { Link } from 'react-router-dom';
 
 export default function Charters() {
     const [isLoaded, setIsLoaded] = React.useState(false);
@@ -23,12 +25,28 @@ export default function Charters() {
         loadCharters();
     }, []);
 
+    const data = [
+        {
+            name: "Make your own Charter",
+            content: "What are some things that all members want to agree on that will help in your team work?"
+        }
+    ]
+
+    const charterTemplatePath = "/charters/charter-templates";
+
     return (
         <div>
             {!isLoaded && <p>Loading...</p>}
             {isLoaded && (
                 <div>
-                    <HeaderBar />
+                    <HeaderBar screenname="Charter" />
+                    <Link to={{
+                        pathname: charterTemplatePath,
+                        state: {
+                            data: data
+                        },
+                    }}>Link Text</Link>
+                    <AddButton path={charterTemplatePath} />
                     <CharterList name="Charters" data_list={charters} />
                     <BottomNavBar />
                 </div>

--- a/src/pages/Charters.js
+++ b/src/pages/Charters.js
@@ -42,7 +42,7 @@ export default function Charters() {
                         },
                     }}>Link Text</Link>
                     <AddButton path={charterTemplatePath} />
-                    <CharterList name="Charters" data_list={charters} />
+                    <CharterList name="Charters" data_list={charters.data} />
                     <BottomNavBar />
                 </div>
             )}

--- a/src/pages/Charters.js
+++ b/src/pages/Charters.js
@@ -25,12 +25,7 @@ export default function Charters() {
         loadCharters();
     }, []);
 
-    const data = [
-        {
-            name: "Make your own Charter",
-            content: "What are some things that all members want to agree on that will help in your team work?"
-        }
-    ]
+    const data = require("./charter-templates.json");
 
     const charterTemplatePath = "/charters/charter-templates";
 

--- a/src/pages/Charters.js
+++ b/src/pages/Charters.js
@@ -3,15 +3,36 @@ import HeaderBar from '../components/nav/HeaderBar';
 import BottomNavBar from '../components/nav/BottomNavbar';
 import CharterList from '../components/charters-page/CharterList';
 
-
 export default function Charters() {
+    const [isLoaded, setIsLoaded] = React.useState(false);
+    const [charters, setCharters] = React.useState([]);
+
+    const loadCharters = async () => {
+        await fetch("http://localhost:3000/api/charters/621d26f81a997588eb8b7979/1")
+            .then(res => res.json())
+            .then(receivedCharters => {
+                setCharters(receivedCharters);
+                setIsLoaded(true);
+            })
+            .catch(error => {
+                setIsLoaded(false);
+                console.log("load data error:", error);
+            })
+    }
+    React.useEffect(() => {
+        loadCharters();
+    }, []);
+
     return (
         <div>
-            <HeaderBar />
-            Charters page
-            {/* TODO: team pictures (horizontal scroll) */}
-            <CharterList />
-            <BottomNavBar />
+            {!isLoaded && <p>Loading...</p>}
+            {isLoaded && (
+                <div>
+                    <HeaderBar />
+                    <CharterList name="Charters" data_list={charters} />
+                    <BottomNavBar />
+                </div>
+            )}
         </div>
     )
 }

--- a/src/pages/Reflections.js
+++ b/src/pages/Reflections.js
@@ -25,8 +25,7 @@ export default function Reflections() {
         loadPosts();
     }, []);
 
-
-    const postPath = "/tasks/create-post";
+    const postPath = "/reflections/create-post";
 
     return (
         <div>

--- a/src/pages/charter-templates.json
+++ b/src/pages/charter-templates.json
@@ -1,0 +1,22 @@
+[
+    {
+        "name": "Make your own Charter",
+        "content": "What times/days does the team commit to meetings and working?",
+        "example": ""
+    },
+    {
+        "name": "Meeting Times",
+        "content": "What are some things that all members want to agree on that will help in your team work?",
+        "example": "Example: Monday afternoon, 1 pm - 2 pm \nWeekdays 8 pm - 10 pm\nSaturday evening, 8 pm - 10 pm(if necessary)"
+    },
+    {
+        "name": "Goals",
+        "content": "What are the team goals?",
+        "example": "Suggestions for establishing team goals:\n- Identify what the team wants to achieve.\n- Make the goals measurable.\n- Distinguish between team goals and individual goals./n- Establish deadlines and stick to them."
+    },
+    {
+        "name": "Communication",
+        "content": "Effective team communication enables teams to achieve goals more effectively.",
+        "example": "Suggestions for establishing communication:\n- Determine primary method of communicating between team members.\n- Establish commitment to communication frequency(daily, weekly, etc)"
+    }
+]


### PR DESCRIPTION
Done
- Fix regression in charter list and item
- Load and display team charters from locally running backend
- Load and display templates from a static json file
- Choose templates to create charters

Next
- Make charter list and item reusable for charter, charter templates, reflection post
- Switch add button color based on screen bg color
- Show must-have charter if not yet complete ([new api](https://github.com/leonkansh/tadashi/commit/82324f3ffc47e2bc1ed53bb648c2ab6ef2d0c696))
- Sync template card width dynamically with viewport

Design Questions
- Think a better way to _display_ charter explanation than placeholder
[Ans] Show as placeholder, once typed, access explanation from an information icon or collapsed dropdown menu like canvas course home page
![Screen Shot 2022-04-15 at 12 22 42 PM](https://user-images.githubusercontent.com/57278679/163623425-fdcc3831-a50d-44e1-9036-80b3de0d4bbe.png)
![Screen Shot 2022-04-15 at 12 22 50 PM](https://user-images.githubusercontent.com/57278679/163623399-221d8d63-188e-4e1f-a0e3-1c8728b2d33e.png)