### PR TITLE
Implement Teambase page with add/edit

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,8 @@ import PostCreation from './pages/PostCreation';
 // import CharterTemplate from './pages/CharterTemplate';
 // import CharterCreation from './pages/CharterCreation';
 import Meeting from './components/teambase/Meeting';
+import Goal from './components/teambase/Goal';
+import Email from './components/teambase/Email';
 
 function App() {
     const orgPrepend = '/orgs/:orgid/teams/:teamid';
@@ -26,7 +28,9 @@ function App() {
 
                 <Route exact path={`${orgPrepend}/teambase`} component={Teambase} />
                 <Route path={`${orgPrepend}/teambase/meetings`} component={Meeting} />
-
+                <Route path={`${orgPrepend}/teambase/goals`} component={Goal} />
+                <Route path={`${orgPrepend}/teambase/emails`} component={Email} />
+                
                 {/* DEPRECATED
                 <Route exact path="/charters" component={Charters} />
                 <Route path="/charters/charter-templates" component={CharterTemplate} />

--- a/src/components/charters-page/CharterItem.js
+++ b/src/components/charters-page/CharterItem.js
@@ -10,6 +10,7 @@ export default function CharterItem({ item }) {
     const postEmoji = async (emoji) => {
         const reaction = { emoji: emoji, postid: item._id };
         fetch("http://localhost:3000/api/board/6263d2fb17033b23e05c0401/1/react", {
+            credentials: 'include',
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'

--- a/src/components/nav/HeaderBar.css
+++ b/src/components/nav/HeaderBar.css
@@ -1,0 +1,9 @@
+.header-title {
+    text-align: center;
+    color: #4B369D;
+    font-family: 'Poppins';
+    font-size: 24px;
+    font-weight: 400;
+    line-height: 36px;
+    letter-spacing: 0em;
+}

--- a/src/components/nav/HeaderBar.css
+++ b/src/components/nav/HeaderBar.css
@@ -1,3 +1,7 @@
+.header-1-container {
+    height: 12vh;
+}
+
 .header-title {
     text-align: center;
     color: #4B369D;
@@ -6,4 +10,10 @@
     font-weight: 400;
     line-height: 36px;
     letter-spacing: 0em;
+}
+
+.btn-back {
+    margin-left: 8px;
+    border-style: none;
+    background-color: white;
 }

--- a/src/components/nav/HeaderBar.js
+++ b/src/components/nav/HeaderBar.js
@@ -1,49 +1,27 @@
 import * as React from 'react';
-import AppBar from '@mui/material/AppBar';
-import Box from '@mui/material/Box';
-import Toolbar from '@mui/material/Toolbar';
-import Typography from '@mui/material/Typography';
-import IconButton from '@mui/material/IconButton';
-import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined';
-import { Link as RouterLink } from 'react-router-dom';
+import { House } from "phosphor-react";
+import { Link } from 'react-router-dom';
+import './HeaderBar.css';
 
-const LinkBehavior = React.forwardRef((props, ref) => (
-    <RouterLink ref={ref} to="/" {...props} />
-));
-
+/**
+ * @screenname { team name passed as string in a prop } 
+ * @returns Rendering a house icon to go home screen and (TODO)click to edit team name
+ */
 export default function HeaderBar({ screenname }) {
+    const btnHomeStyle = {
+        paddingLeft: "20px",
+        position: "absolute"
+    }
+    
     return (
-        <Box>
-            <AppBar position="static">
-                <Toolbar>
-                    {/* FIXME: center align screen name from homebtn to rightest */}
-                    <IconButton
-                        size="large"
-                        edge="start"
-                        color="inherit"
-                        aria-label="home"
-                        sx={{ mr: 2 }}
-                        component={RouterLink}
-                        to="/"
-                    >
-                        <HomeOutlinedIcon />
-                    </IconButton>
-                    <Box
-                        sx={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            flexDirection: 'column'
-                        }}
-                    >
-                        <Typography variant="h6" component="p" sx={{ flexGrow: 1 }}>
-                            {screenname}
-                        </Typography>
-                        <Typography variant="h8" component="p" sx={{ flexGrow: 1 }}>
-                            Team Name
-                        </Typography>
-                    </Box>
-                </Toolbar>
-            </AppBar>
-        </Box>
+        <div className='header-1-container'>
+            <Link className="btn-home" to="/" style={btnHomeStyle}>
+                <House size={35} color="#383E56"/>
+            </Link>
+            <div className='header-title'>
+                {/* TODO: click to change team name */}
+                <p>{screenname}</p>
+            </div>
+        </div>
     );
 }

--- a/src/components/nav/HeaderBarBackArrow.js
+++ b/src/components/nav/HeaderBarBackArrow.js
@@ -1,17 +1,13 @@
 import * as React from 'react';
-import AppBar from '@mui/material/AppBar';
-import Box from '@mui/material/Box';
-import Toolbar from '@mui/material/Toolbar';
-import Typography from '@mui/material/Typography';
-import IconButton from '@mui/material/IconButton';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { useHistory } from 'react-router-dom';
+import { ArrowLeft } from 'phosphor-react';
+import './HeaderBar.css'
 
 /**
- * TODO: takes two props: screen name and team name
- * @returns headbar with a back arrow that returns to last page
+ * @screenname { team name passed as string in a prop } 
+ * @returns Rendering a back arrow icon to return to last page
  */
-export default function HeaderBarBackArrow() {
+export default function HeaderBarBackArrow({ screenname }) {
 
     const history = useHistory()
 
@@ -19,37 +15,18 @@ export default function HeaderBarBackArrow() {
         history.goBack()
     }
 
+    const btnHomeStyle = {
+        position: "absolute"
+    }
+
     return (
-        <Box>
-            <AppBar position="static" sx={{ bgcolor: "white" }} elevation={0}>
-                <Toolbar>
-                    <IconButton
-                        size="large"
-                        edge="start"
-                        color="inherit"
-                        aria-label="go back to last page"
-                        sx={{ mr: 2, color: "primary.main" }}
-                        onClick={goBack}
-                    >
-                        <ArrowBackIcon />
-                    </IconButton>
-                    <Box
-                        sx={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            flexDirection: 'column',
-                            color: "primary.main"
-                        }}
-                    >
-                        <Typography variant="h6" component="p" sx={{ flexGrow: 1 }}>
-                            Screen Name
-                        </Typography>
-                        <Typography variant="h8" component="p" sx={{ flexGrow: 1 }}>
-                            Team Name
-                        </Typography>
-                    </Box>
-                </Toolbar>
-            </AppBar>
-        </Box>
+        <div className='header-1-container'>
+            <button className="btn-back" onClick={goBack} style={btnHomeStyle}>
+                <ArrowLeft size={35} color="#4B369D" />
+            </button>
+            <div className='header-title'>
+                <p>{screenname}</p>
+            </div>
+        </div>
     );
 }

--- a/src/components/tasks-page/TodoList.js
+++ b/src/components/tasks-page/TodoList.js
@@ -22,6 +22,7 @@ export default function TodoList() {
     const changeComplete = async (todoId, completed, assignmentId) => {
         const todo = { todoId: todoId, completed: completed };
         fetch(`http://localhost:3000/api/assignments/6263d2fb17033b23e05c0401/${assignmentId}/team/1`, {
+            credentials: 'include',
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json'
@@ -40,6 +41,7 @@ export default function TodoList() {
     const deleteTodo = async (todoId, assignmentId) => {
         const todo = { todoId: todoId };
         fetch(`http://localhost:3000/api/assignments/6263d2fb17033b23e05c0401/${assignmentId}/team/1`, {
+            credentials: 'include',
             method: 'DELETE',
             headers: {
                 'Content-Type': 'application/json'

--- a/src/components/teambase/Email.js
+++ b/src/components/teambase/Email.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import { useHistory, useParams } from 'react-router-dom';
+import EmailsInputGroup from './EmailsInputGroup';
+import Stack from '@mui/material/Stack';
+import HeaderBarBackArrow from '../nav/HeaderBarBackArrow'
+import './Meeting.css';
+
+export default function Email() {
+    const history = useHistory()
+    const { orgid, teamid } = useParams();
+    const teambasePath = `/orgs/${orgid}/teams/${teamid}/teambase`;
+    const [profiles, setProfiles] = React.useState([]);
+    const [isLoaded, setIsLoaded] = React.useState(false);
+    const [num, setNum] = React.useState(profiles.length);
+
+    const loadProfiles = async () => {
+        await fetch(`http://localhost:3000/api/charters/${orgid}/${teamid}/single?name=Profile`)
+            .then(res => res.json())
+            .then(receivedPosts => {
+                setProfiles(receivedPosts.data[0].profile);
+                setIsLoaded(true);
+            })
+            .catch(error => {
+                setIsLoaded(false);
+                console.log("load data error:", error);
+            })
+    }
+    React.useEffect(() => {
+        loadProfiles();
+    }, []);
+
+    const addEmail = (e) => {
+        e.preventDefault();
+        let data = profiles;
+        data.push({
+            name: null,
+            email: null
+        });
+        setProfiles(data);
+        setNum(num + 1);
+    }
+
+    const saveEmail = async (e) => {
+        e.preventDefault();
+        const body = { name: "Profile", profile: profiles }
+        fetch(`http://localhost:3000/api/charters/${orgid}/${teamid}`, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(body)
+        }).catch(e => console.log("error", e));
+        history.push(teambasePath);
+    }
+
+    return (
+        <div>
+            {!isLoaded && <p>Loading...</p>}
+            {isLoaded && (
+                <div>
+                    <HeaderBarBackArrow screenname="Emails" />
+                    <Stack>
+                        {profiles.map((profile, index) => {
+                            return (
+                                <EmailsInputGroup
+                                    profiles={profiles}
+                                    setProfiles={setProfiles}
+                                    profile={profile}
+                                    index={index}
+                                />
+                            )
+                        })}
+                        <div className='group-btns'>
+                            <button className="btn-add-more" onClick={addEmail}>Add Email</button>                            
+                            <button className="btn-save" onClick={saveEmail}>Save</button>
+                        </div>
+                    </Stack>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/src/components/teambase/Email.js
+++ b/src/components/teambase/Email.js
@@ -14,7 +14,9 @@ export default function Email() {
     const [num, setNum] = React.useState(profiles.length);
 
     const loadProfiles = async () => {
-        await fetch(`http://localhost:3000/api/charters/${orgid}/${teamid}/single?name=Profile`)
+        await fetch(`http://localhost:3000/api/charters/${orgid}/${teamid}/single?name=Profile`, {
+                credentials: 'include'
+            })
             .then(res => res.json())
             .then(receivedPosts => {
                 setProfiles(receivedPosts.data[0].profile);
@@ -44,6 +46,7 @@ export default function Email() {
         e.preventDefault();
         const body = { name: "Profile", profile: profiles }
         fetch(`http://localhost:3000/api/charters/${orgid}/${teamid}`, {
+            credentials: 'include',
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json'

--- a/src/components/teambase/EmailCard.js
+++ b/src/components/teambase/EmailCard.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import './Meeting.css';
+
+export default function EmailCard({ contact }) {
+    return (
+        <div className="meeting-card">
+            <h2 className="card-name">{contact.name}</h2>
+            <p className="card-field">{contact.email}</p>
+        </div>
+    );
+}

--- a/src/components/teambase/EmailsInputGroup.js
+++ b/src/components/teambase/EmailsInputGroup.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import './Meeting.css';
+
+/**
+ * @param { profiles, setProfiles, this_profile, index of goal list }
+ * @returns parsed team goal content in an input form card
+ */
+export default function EmailsInputGroup({ profiles, setProfiles, profile, index }) {    
+    const [name, setName] = React.useState(profile.name);
+    const [email, setEmail] = React.useState(profile.email);
+
+    const handleName = (e) => {
+        setName(e.target.value);
+        let data = profiles;
+        data[index].name = e.target.value;
+        setProfiles(data);
+    }
+    const handleEmail = (e) => {
+        setEmail(e.target.value);
+        let data = profiles;
+        data[index].email = e.target.value;
+        setProfiles(data);
+        console.log(data)
+    }
+
+    return (
+        <div key={`email ${index}`} className='input-group'>
+            <input 
+                className="input-name" 
+                type="text" 
+                name="name"
+                placeholder='Name'
+                value={name} 
+                size="50" 
+                onChange={handleName}
+            />
+
+            <input 
+                className="input-name" 
+                type="text" 
+                name="name"
+                placeholder='Enter the email!'
+                value={email} 
+                size="50" 
+                onChange={handleEmail}
+            />
+        </div>
+    )
+}

--- a/src/components/teambase/Goal.js
+++ b/src/components/teambase/Goal.js
@@ -14,7 +14,9 @@ export default function Goal() {
     const [num, setNum] = React.useState(goals.length);
     console.log("goal.js", goals);
     const loadGoals = async () => {
-        await fetch(`http://localhost:3000/api/charters/${orgid}/${teamid}/single?name=Goals`)
+        await fetch(`http://localhost:3000/api/charters/${orgid}/${teamid}/single?name=Goals`, {
+                credentials: 'include'
+            })
             .then(res => res.json())
             .then(receivedPosts => {
                 setGoals(receivedPosts.data[0].goals);
@@ -41,6 +43,7 @@ export default function Goal() {
         e.preventDefault();
         const body = { name: "Goals", goals: goals }
         fetch(`http://localhost:3000/api/charters/${orgid}/${teamid}`, {
+            credentials: 'include',
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json'

--- a/src/components/teambase/Goal.js
+++ b/src/components/teambase/Goal.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import { useHistory, useParams, Link } from 'react-router-dom';
+import GoalsInputGroup from './GoalsInputGroup';
+import Stack from '@mui/material/Stack';
+import HeaderBarBackArrow from '../nav/HeaderBarBackArrow'
+import './Meeting.css';
+
+export default function Goal() {
+    const history = useHistory()
+    const { orgid, teamid } = useParams();
+    const teambasePath = `/orgs/${orgid}/teams/${teamid}/teambase`;
+    const [goals, setGoals] = React.useState([]);
+    const [isLoaded, setIsLoaded] = React.useState(false);
+    const [num, setNum] = React.useState(goals.length);
+    console.log("goal.js", goals);
+    const loadGoals = async () => {
+        await fetch(`http://localhost:3000/api/charters/${orgid}/${teamid}/single?name=Goals`)
+            .then(res => res.json())
+            .then(receivedPosts => {
+                setGoals(receivedPosts.data[0].goals);
+                setIsLoaded(true);
+            })
+            .catch(error => {
+                setIsLoaded(false);
+                console.log("load data error:", error);
+            })
+    }
+    React.useEffect(() => {
+        loadGoals();
+    }, []);
+
+    const addGoal = (e) => {
+        e.preventDefault();
+        let data = goals;
+        data.push(null);
+        setGoals(data);
+        setNum(num + 1);
+    }
+
+    const saveGoal = async (e) => {
+        e.preventDefault();
+        const body = { name: "Goals", goals: goals }
+        fetch(`http://localhost:3000/api/charters/${orgid}/${teamid}`, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(body)
+        }).catch(e => console.log("error", e));
+        history.push(teambasePath);
+    }
+
+    return (
+        <div>
+            {!isLoaded && <p>Loading...</p>}
+            {isLoaded && (
+                <div>
+                    <HeaderBarBackArrow screenname="Team Goals" />
+                    <Stack>
+                        {goals.map((goal, index) => {
+                            return (
+                                <GoalsInputGroup
+                                    goals={goals}
+                                    setGoals={setGoals}
+                                    goal={goal}
+                                    index={index}
+                                />
+                            )
+                        })}
+                        <div className='group-btns'>
+                            <button className="btn-add-more" onClick={addGoal}>Add Goal</button>                            
+                            <button className="btn-save" onClick={saveGoal}>Save</button>
+                        </div>
+                    </Stack>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/src/components/teambase/GoalCard.js
+++ b/src/components/teambase/GoalCard.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import './Meeting.css';
+
+export default function GoalCard({ goal }) {
+    return (
+        <div className="meeting-card">
+            <h2 className="card-name">{goal}</h2>
+        </div>
+    );
+}

--- a/src/components/teambase/GoalsInputGroup.js
+++ b/src/components/teambase/GoalsInputGroup.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import './Meeting.css';
+
+/**
+ * @param { goals, setGoals, this_goal, index of goal list }
+ * @returns parsed team goal content in an input form card
+ */
+export default function GoalsInputGroup({ goals, setGoals, goal, index }) {    
+    const [name, setName] = React.useState(goal);
+
+    const handleName = (e) => {
+        setName(e.target.value);
+        let data = goals;
+        data[index] = e.target.value;
+        setGoals(data);
+    }
+    return (
+        <div key={`goal ${index}`} className='input-group'>
+            <input 
+                className="input-name" 
+                type="text" 
+                name="name"
+                placeholder='Enter a team goal!'
+                value={name} 
+                size="50" 
+                onChange={handleName}
+            />
+        </div>
+    )
+}

--- a/src/components/teambase/InputGroup.js
+++ b/src/components/teambase/InputGroup.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import Button from '@mui/material/Button';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import './Meeting.css';
+
+const convertTime = (time) => {
+    const hour = Math.trunc(time);
+    let minute = Math.trunc((time % 1) * 60);
+    minute = minute < 10 ? `0${minute}` : minute;
+    return `${hour}:${minute}`;
+}
+
+const revertTime = (time) => {
+    const hour = time.split(":")[0] * 1;
+    const minute = time.split(":")[1] / 60;
+    return hour + minute;
+}
+
+// console.log(revertTime("15:50"));
+// console.log(convertTime(revertTime("15:50")));
+
+/**
+ * 
+ * @param { setDay, this_meeting, index of meeting list }
+ * @returns parsed meeting content in an input form card
+ */
+export default function InputGroup({ setMeetings, meeting, index }) {
+    const [anchorEl, setAnchorEl] = React.useState(null);
+    const open = Boolean(anchorEl);
+    const [day, setDay] = React.useState();
+    const handleClick = (event) => {
+      setAnchorEl(event.currentTarget);
+    };
+    const handleDay = (e) => {
+        e.preventDefault();
+        if (e.target.value) setDay(e.target.value)
+        setAnchorEl(null);
+    };
+
+    const [name, setName] = React.useState(meeting.name);
+    const [start, setStart] = React.useState(convertTime(meeting.start));
+    const [end, setEnd] = React.useState(convertTime(meeting.end));
+
+    const days = ["Mondays", "Tuesdays", "Wednesdays", "Thursdays", "Fridays", "Saturdays", "Sundays"];
+    
+    return (
+        <div className='input-group'>
+            <input className="input-name" type="text" name="name" value={name} size="50" onChange={e => setName(e.target.value)}/>
+            <p>When will it be?</p>
+            <Button
+                id="basic-button"
+                aria-controls={open ? 'basic-menu' : undefined}
+                aria-haspopup="true"
+                aria-expanded={open ? 'true' : undefined}
+                onClick={handleClick}
+            >
+                day
+            </Button>
+            <Menu
+                id="basic-menu"
+                anchorEl={anchorEl}
+                open={open}
+                onClose={handleDay}
+                MenuListProps={{
+                'aria-labelledby': 'basic-button',
+                }}
+                defaultValue={0}
+            >
+                {days.map(
+                    (day, index) => <MenuItem value={index} onClick={handleDay}>{day}</MenuItem>
+                )}
+            </Menu>
+            
+            <p>{meeting.weekday}</p>
+            <input className="input-time" value={start} onChange={e => setStart(e.target.value)} />
+            <input className="input-time" value={end} onChange={e => setEnd(e.target.value)} />
+
+        </div>
+    )
+}

--- a/src/components/teambase/InputGroup.js
+++ b/src/components/teambase/InputGroup.js
@@ -74,6 +74,12 @@ export default function InputGroup({ meetings, setMeetings, meeting, index }) {
 
     const days = ["Mondays", "Tuesdays", "Wednesdays", "Thursdays", "Fridays", "Saturdays", "Sundays"];
 
+    const handleName = (e) => {
+        setName(e.target.value);
+        let data = meetings;
+        data[index].name = e.target.value;
+        setMeetings(data);
+    }
     return (
         <div className='input-group'>
             <Stack>
@@ -83,7 +89,7 @@ export default function InputGroup({ meetings, setMeetings, meeting, index }) {
                     name="name" 
                     value={name} 
                     size="50" 
-                    onChange={e => setName(e.target.value)}
+                    onChange={handleName}
                 />
                 
                 <p>When will it be?</p>
@@ -117,9 +123,9 @@ export default function InputGroup({ meetings, setMeetings, meeting, index }) {
                 
                 <div className='inline-div'>
                     <Clock size={24} />
-                    <input className="input-time" value={start} onChange={handleStart} />
+                    <input className="input-time" value={start < 0 ? 0 : start} onChange={handleStart} />
                     <p> - </p>
-                    <input className="input-time" value={end} onChange={handleEnd} />
+                    <input className="input-time" value={end < 0 ? 0 : end} onChange={handleEnd} />
                 </div>
             </Stack>
         </div>

--- a/src/components/teambase/InputGroup.js
+++ b/src/components/teambase/InputGroup.js
@@ -1,8 +1,12 @@
 import React from 'react';
-import Button from '@mui/material/Button';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import './Meeting.css';
+
+import IconButton from '@mui/material/IconButton';
+import { CalendarBlank, Clock } from 'phosphor-react';
+
+import Stack from '@mui/material/Stack';
 
 const convertTime = (time) => {
     const hour = Math.trunc(time);
@@ -17,65 +21,107 @@ const revertTime = (time) => {
     return hour + minute;
 }
 
-// console.log(revertTime("15:50"));
-// console.log(convertTime(revertTime("15:50")));
+const convertDay = (day) => {
+    if (day > 7 && day < 0) return;
+    const days = ["Mondays", "Tuesdays", "Wednesdays", "Thursdays", "Fridays", "Saturdays", "Sundays"];
+    return days[day];
+}
+
+const revertDay = (day) => {
+    const days = ["Mondays", "Tuesdays", "Wednesdays", "Thursdays", "Fridays", "Saturdays", "Sundays"];
+    return days.indexOf(day);
+}
 
 /**
- * 
  * @param { setDay, this_meeting, index of meeting list }
  * @returns parsed meeting content in an input form card
  */
-export default function InputGroup({ setMeetings, meeting, index }) {
+export default function InputGroup({ meetings, setMeetings, meeting, index }) {
     const [anchorEl, setAnchorEl] = React.useState(null);
     const open = Boolean(anchorEl);
-    const [day, setDay] = React.useState();
-    const handleClick = (event) => {
-      setAnchorEl(event.currentTarget);
-    };
-    const handleDay = (e) => {
-        e.preventDefault();
-        if (e.target.value) setDay(e.target.value)
-        setAnchorEl(null);
-    };
-
+    
+    const [day, setDay] = React.useState(convertDay(meeting.weekday));
     const [name, setName] = React.useState(meeting.name);
     const [start, setStart] = React.useState(convertTime(meeting.start));
     const [end, setEnd] = React.useState(convertTime(meeting.end));
 
+    const handleClick = (event) => {
+      setAnchorEl(event.currentTarget);
+    };
+
+    const handleDay = (e) => {
+        e.preventDefault();
+        setDay(convertDay(e.target.value));
+        let data = meetings;
+        data[index].weekday = e.target.value;
+        setMeetings(data);
+        setAnchorEl(null);
+    };
+
+    const handleStart = (e) => {
+        setStart(e.target.value);
+        let data = meetings;
+        data[index].start = revertTime(e.target.value);
+        setMeetings(data);
+    }
+
+    const handleEnd = (e) => {
+        setEnd(e.target.value);
+        let data = meetings;
+        data[index].end = revertTime(e.target.value);
+        setMeetings(data);
+    }
+
     const days = ["Mondays", "Tuesdays", "Wednesdays", "Thursdays", "Fridays", "Saturdays", "Sundays"];
-    
+
     return (
         <div className='input-group'>
-            <input className="input-name" type="text" name="name" value={name} size="50" onChange={e => setName(e.target.value)}/>
-            <p>When will it be?</p>
-            <Button
-                id="basic-button"
-                aria-controls={open ? 'basic-menu' : undefined}
-                aria-haspopup="true"
-                aria-expanded={open ? 'true' : undefined}
-                onClick={handleClick}
-            >
-                day
-            </Button>
-            <Menu
-                id="basic-menu"
-                anchorEl={anchorEl}
-                open={open}
-                onClose={handleDay}
-                MenuListProps={{
-                'aria-labelledby': 'basic-button',
-                }}
-                defaultValue={0}
-            >
-                {days.map(
-                    (day, index) => <MenuItem value={index} onClick={handleDay}>{day}</MenuItem>
-                )}
-            </Menu>
-            
-            <p>{meeting.weekday}</p>
-            <input className="input-time" value={start} onChange={e => setStart(e.target.value)} />
-            <input className="input-time" value={end} onChange={e => setEnd(e.target.value)} />
+            <Stack>
+                <input 
+                    className="input-name" 
+                    type="text" 
+                    name="name" 
+                    value={name} 
+                    size="50" 
+                    onChange={e => setName(e.target.value)}
+                />
+                
+                <p>When will it be?</p>
 
+                <div className='inline-div'>
+                    <IconButton
+                        id="basic-button"
+                        aria-controls={open ? 'basic-menu' : undefined}
+                        aria-haspopup="true"
+                        aria-expanded={open ? 'true' : undefined}
+                        onClick={handleClick}
+                    >
+                        <CalendarBlank size={24} />
+                    </IconButton>
+                    <Menu
+                        id="basic-menu"
+                        anchorEl={anchorEl}
+                        open={open}
+                        onClose={handleDay}
+                        MenuListProps={{
+                        'aria-labelledby': 'basic-button',
+                        }}
+                    >
+                        {days.map(
+                            (day, index) => <MenuItem value={index} onClick={handleDay}>{day}</MenuItem>
+                        )}
+                    </Menu>
+
+                    <p className='input-time'>{day}</p>
+                </div>
+                
+                <div className='inline-div'>
+                    <Clock size={24} />
+                    <input className="input-time" value={start} onChange={handleStart} />
+                    <p> - </p>
+                    <input className="input-time" value={end} onChange={handleEnd} />
+                </div>
+            </Stack>
         </div>
     )
 }

--- a/src/components/teambase/Meeting.css
+++ b/src/components/teambase/Meeting.css
@@ -5,6 +5,8 @@
     border-right: none;
     width: 270px;
     font-size: large;
+    font-family: 'Poppins';
+    color: #4B369D;
 }
 
 .input-group {
@@ -94,4 +96,17 @@ p, h1, h2, h3 {
     height: 50px;
     color: #FFFFFF;
     background-color: #4B369D;
+}
+
+::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */
+    color: #4B369D;
+    opacity: 0.5; /* Firefox */
+  }
+  
+:-ms-input-placeholder { /* Internet Explorer 10-11 */
+    color: #4B369D;
+}
+
+::-ms-input-placeholder { /* Microsoft Edge */
+    color: #4B369D;
 }

--- a/src/components/teambase/Meeting.css
+++ b/src/components/teambase/Meeting.css
@@ -3,14 +3,18 @@
     border-top: none;
     border-left: none;
     border-right: none;
-    width: 288px;
+    width: 270px;
     font-size: large;
 }
 
 .input-group {
+    position: relative;
     padding-top: 23px;
     padding-left: 59px;
     padding-bottom: 31px;
+    border: 1px solid #4B369D;
+    border-radius: 15px;
+    margin: 12.5px;
 }
 
 .input-time {
@@ -21,4 +25,12 @@
     width: 68px;
     font-size: large;
     text-align: center;
+}
+
+.inline-div {
+    display: inline-flex;
+}
+
+.container {
+    position: relative;
 }

--- a/src/components/teambase/Meeting.css
+++ b/src/components/teambase/Meeting.css
@@ -1,0 +1,24 @@
+.input-name {
+    border: .1px solid #C4C4C4;
+    border-top: none;
+    border-left: none;
+    border-right: none;
+    width: 288px;
+    font-size: large;
+}
+
+.input-group {
+    padding-top: 23px;
+    padding-left: 59px;
+    padding-bottom: 31px;
+}
+
+.input-time {
+    border: .1px solid #C4C4C4;
+    border-top: none;
+    border-left: none;
+    border-right: none;
+    width: 68px;
+    font-size: large;
+    text-align: center;
+}

--- a/src/components/teambase/Meeting.css
+++ b/src/components/teambase/Meeting.css
@@ -34,3 +34,31 @@
 .container {
     position: relative;
 }
+
+.meeting-card {
+    border: 1px solid #4B369D;
+    border-radius: 8px;
+    margin-top: 23px;
+    margin-left: 20px;
+    margin-right: 20px;
+}
+
+.card-name {
+    font-weight: lighter;
+    font-size: 18px;
+    padding-left: 33px;
+    padding-bottom: 0px;
+}
+
+.card-field {
+    font-size: 14;
+    padding-left: 48px;
+}
+
+.card-name, .card-field {
+    color: #4B369D;
+}
+
+p, h1, h2, h3 {
+    font-family: 'Poppins';
+}

--- a/src/components/teambase/Meeting.css
+++ b/src/components/teambase/Meeting.css
@@ -62,3 +62,36 @@
 p, h1, h2, h3 {
     font-family: 'Poppins';
 }
+
+.group-btns {
+    display: inline-flex;
+    justify-content: space-evenly;
+    margin-top: 20px;
+    margin-bottom: 50px;
+}
+
+.btn-add-more, .btn-save {
+    margin-left: 5vw;
+    margin-right: 5vw;
+    border: 1px solid #4B369D;
+    border-radius: 15px;
+    font-size: 1em;
+    font-family: 'Poppins';
+    font-style: normal;
+    font-weight: 500;
+    line-height: 27px;
+}
+
+.btn-add-more {
+    width: 48vw;
+    height: 50px;
+    color: #4B369D;
+    background-color: white;
+}
+
+.btn-save {
+    width: 37vw;
+    height: 50px;
+    color: #FFFFFF;
+    background-color: #4B369D;
+}

--- a/src/components/teambase/Meeting.js
+++ b/src/components/teambase/Meeting.js
@@ -1,13 +1,12 @@
 import React from 'react';
 import { useHistory, useParams } from 'react-router-dom';
-import InputGroup from './InputGroup';
+import MeetingsInputGroup from './MeetingsInputGroup';
 import Stack from '@mui/material/Stack';
 import HeaderBarBackArrow from '../nav/HeaderBarBackArrow'
 import './Meeting.css';
 
 export default function Meeting() {
     const history = useHistory()
-    const goBack = () => history.goBack();
     const { orgid, teamid } = useParams();
     const teambasePath = `/orgs/${orgid}/teams/${teamid}/teambase`;
     const [meetings, setMeetings] = React.useState([]);
@@ -65,7 +64,7 @@ export default function Meeting() {
                     <Stack>
                         {meetings.map((meeting, index) => {
                             return (
-                                <InputGroup
+                                <MeetingsInputGroup
                                     meetings={meetings}
                                     setMeetings={setMeetings}
                                     meeting={meeting}

--- a/src/components/teambase/Meeting.js
+++ b/src/components/teambase/Meeting.js
@@ -14,7 +14,9 @@ export default function Meeting() {
     const [num, setNum] = React.useState(meetings.length);
 
     const loadMeetings = async () => {
-        await fetch(`http://localhost:3000/api/charters/${orgid}/${teamid}/single?name=Meeting Times`)
+        await fetch(`http://localhost:3000/api/charters/${orgid}/${teamid}/single?name=Meeting Times`,{
+                credentials: 'include'
+            })
             .then(res => res.json())
             .then(receivedPosts => {
                 setMeetings(receivedPosts.data[0].meetingTimes);
@@ -46,6 +48,7 @@ export default function Meeting() {
         e.preventDefault();
         const body = { name: "Meeting Times", meetingTimes: meetings }
         fetch(`http://localhost:3000/api/charters/${orgid}/${teamid}`, {
+            credentials: 'include',
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json'

--- a/src/components/teambase/Meeting.js
+++ b/src/components/teambase/Meeting.js
@@ -68,6 +68,7 @@ export default function Meeting() {
                         {meetings.map((meeting, index) => {
                             return (
                                 <InputGroup
+                                    meetings={meetings}
                                     setMeetings={setMeetings}
                                     meeting={meeting}
                                     index={index}
@@ -78,7 +79,7 @@ export default function Meeting() {
                         {/* addMeeting */}
                         <button>Add Meeting Time</button>
 
-                        {/* saveMeeting */}
+                        {/* saveMeeting : body = meetings */}
                         <Link to={`/orgs/${orgid}/teams/${teamid}/teambase`}>
                             <button onClick={e => console.log("post and go back")}>Save</button>
                         </Link>

--- a/src/components/teambase/Meeting.js
+++ b/src/components/teambase/Meeting.js
@@ -1,18 +1,15 @@
 import React from 'react';
-import { useHistory, useParams, Link } from 'react-router-dom';
-import IconButton from '@mui/material/IconButton';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import Stack from '@mui/material/Stack';
-import './Meeting.css';
+import { useHistory, useParams } from 'react-router-dom';
 import InputGroup from './InputGroup';
+import Stack from '@mui/material/Stack';
+import HeaderBarBackArrow from '../nav/HeaderBarBackArrow'
+import './Meeting.css';
 
 export default function Meeting() {
-    const header = "Add Meeting";
     const history = useHistory()
-    const goBack = () => {
-        history.goBack()
-    }
+    const goBack = () => history.goBack();
     const { orgid, teamid } = useParams();
+    const teambasePath = `/orgs/${orgid}/teams/${teamid}/teambase`;
     const [meetings, setMeetings] = React.useState([]);
     const [isLoaded, setIsLoaded] = React.useState(false);
     const [num, setNum] = React.useState(meetings.length);
@@ -56,6 +53,7 @@ export default function Meeting() {
             },
             body: JSON.stringify(body)
         }).catch(e => console.log("error", e));
+        history.push(teambasePath);
     }
 
     return (
@@ -63,17 +61,7 @@ export default function Meeting() {
             {!isLoaded && <p>Loading...</p>}
             {isLoaded && (
                 <div>
-                    <IconButton
-                        size="large"
-                        edge="start"
-                        color="inherit"
-                        aria-label="home"
-                        sx={{ mr: 2, color: "primary.main", left: 22, top: 23 }}
-                        onClick={goBack}
-                    >
-                        <ArrowBackIcon sx={{ fontSize: 35 }} />
-                    </IconButton>
-
+                    <HeaderBarBackArrow screenname="Meeting Times" />
                     <Stack>
                         {meetings.map((meeting, index) => {
                             return (
@@ -85,12 +73,10 @@ export default function Meeting() {
                                 />
                             )
                         })}
-
-                        <button onClick={addMeeting}>Add Meeting Time</button>
-
-                        <Link to={`/orgs/${orgid}/teams/${teamid}/teambase`}>
-                            <button onClick={saveMeeting}>Save</button>
-                        </Link>
+                        <div className='group-btns'>
+                            <button className="btn-add-more" onClick={addMeeting}>Add Meeting Time</button>                            
+                            <button className="btn-save" onClick={saveMeeting}>Save</button>
+                        </div>
                     </Stack>
                 </div>
             )}

--- a/src/components/teambase/Meeting.js
+++ b/src/components/teambase/Meeting.js
@@ -12,12 +12,10 @@ export default function Meeting() {
     const goBack = () => {
         history.goBack()
     }
-
     const { orgid, teamid } = useParams();
-
-    /** TODO: store meeting_obj_list as useState : update entire list everytime */
     const [meetings, setMeetings] = React.useState([]);
     const [isLoaded, setIsLoaded] = React.useState(false);
+    const [num, setNum] = React.useState(meetings.length);
 
     const loadMeetings = async () => {
         await fetch(`http://localhost:3000/api/charters/${orgid}/${teamid}/single?name=Meeting Times`)
@@ -35,15 +33,22 @@ export default function Meeting() {
         loadMeetings();
     }, []);
 
-    const addMeeting = () => {
-        // TODO:
-        // setMeetings(data + data.push(placeholder))
-        // so it renders a new InputGroup with placeholder
+    const addMeeting = (e) => {
+        e.preventDefault();
+        let data = meetings;
+        data.push({
+            name: null,
+            weekday: null,
+            start: null,
+            end: null
+        });
+        setMeetings(data);
+        setNum(num + 1);
     }
 
-    const saveMeeting = async () => {
+    const saveMeeting = async (e) => {
+        e.preventDefault();
         const body = { name: "Meeting Times", meetingTimes: meetings }
-        console.log("body", body);
         fetch(`http://localhost:3000/api/charters/${orgid}/${teamid}`, {
             method: 'PUT',
             headers: {
@@ -80,13 +85,11 @@ export default function Meeting() {
                                 />
                             )
                         })}
-                        
-                        {/* addMeeting */}
-                        <button>Add Meeting Time</button>
 
-                        {/* saveMeeting : body = meetings */}
+                        <button onClick={addMeeting}>Add Meeting Time</button>
+
                         <Link to={`/orgs/${orgid}/teams/${teamid}/teambase`}>
-                            <button onClick={e => saveMeeting()}>Save</button>
+                            <button onClick={saveMeeting}>Save</button>
                         </Link>
                     </Stack>
                 </div>

--- a/src/components/teambase/Meeting.js
+++ b/src/components/teambase/Meeting.js
@@ -41,11 +41,16 @@ export default function Meeting() {
         // so it renders a new InputGroup with placeholder
     }
 
-    const saveMeeting = () => {
-        // TODO: 
-        // revert start and end time
-        // call POST api
-        // route to Teambase
+    const saveMeeting = async () => {
+        const body = { name: "Meeting Times", meetingTimes: meetings }
+        console.log("body", body);
+        fetch(`http://localhost:3000/api/charters/${orgid}/${teamid}`, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(body)
+        }).catch(e => console.log("error", e));
     }
 
     return (
@@ -81,7 +86,7 @@ export default function Meeting() {
 
                         {/* saveMeeting : body = meetings */}
                         <Link to={`/orgs/${orgid}/teams/${teamid}/teambase`}>
-                            <button onClick={e => console.log("post and go back")}>Save</button>
+                            <button onClick={e => saveMeeting()}>Save</button>
                         </Link>
                     </Stack>
                 </div>

--- a/src/components/teambase/Meeting.js
+++ b/src/components/teambase/Meeting.js
@@ -1,75 +1,90 @@
 import React from 'react';
-import { useHistory, useParams } from 'react-router-dom';
+import { useHistory, useParams, Link } from 'react-router-dom';
 import IconButton from '@mui/material/IconButton';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import TextField from '@mui/material/TextField';
-import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
+import './Meeting.css';
+import InputGroup from './InputGroup';
 
-/** TODO: refactor post creation for add/edit meeting */
-/** TODO: Fetch get all meetings, if nothing, header add, else, header edit */
 export default function Meeting() {
     const header = "Add Meeting";
-
     const history = useHistory()
-
     const goBack = () => {
         history.goBack()
     }
 
     const { orgid, teamid } = useParams();
-    const [title, setTitle] = React.useState("");
-    const [content, setContent] = React.useState("");
-    const [date, setDate] = React.useState(new Date());
 
-    const postData = () => {
-        setDate(new Date());
-        const post = { title, content, date };
-        fetch(`http://localhost:3000/api/board/${orgid}/${teamid}`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify(post)
-        })
+    /** TODO: store meeting_obj_list as useState : update entire list everytime */
+    const [meetings, setMeetings] = React.useState([]);
+    const [isLoaded, setIsLoaded] = React.useState(false);
+
+    const loadMeetings = async () => {
+        await fetch(`http://localhost:3000/api/charters/${orgid}/${teamid}/single?name=Meeting Times`)
+            .then(res => res.json())
+            .then(receivedPosts => {
+                setMeetings(receivedPosts.data[0].meetingTimes);
+                setIsLoaded(true);
+            })
+            .catch(error => {
+                setIsLoaded(false);
+                console.log("load data error:", error);
+            })
+    }
+    React.useEffect(() => {
+        loadMeetings();
+    }, []);
+
+    const addMeeting = () => {
+        // TODO:
+        // setMeetings(data + data.push(placeholder))
+        // so it renders a new InputGroup with placeholder
+    }
+
+    const saveMeeting = () => {
+        // TODO: 
+        // revert start and end time
+        // call POST api
+        // route to Teambase
     }
 
     return (
         <div>
-            <IconButton
-                size="large"
-                edge="start"
-                color="inherit"
-                aria-label="home"
-                sx={{ mr: 2, color: "primary.main", left: 22, top: 23 }}
-                onClick={goBack}
-            >
-                <ArrowBackIcon sx={{ fontSize: 35 }} />
-            </IconButton>
-            <h1>{header}</h1>
-            <Stack>
-                <TextField
-                    placeholder="title"
-                    value={title}
-                    sx={{ fontSize: 24, maxWidth: 300, p: 1, pb: 3 }}
-                    onChange={event => setTitle(event.target.value)}
-                />
+            {!isLoaded && <p>Loading...</p>}
+            {isLoaded && (
+                <div>
+                    <IconButton
+                        size="large"
+                        edge="start"
+                        color="inherit"
+                        aria-label="home"
+                        sx={{ mr: 2, color: "primary.main", left: 22, top: 23 }}
+                        onClick={goBack}
+                    >
+                        <ArrowBackIcon sx={{ fontSize: 35 }} />
+                    </IconButton>
 
-                <TextField
-                    id="outlined-multiline-static"
-                    label="Enter your reflection"
-                    multiline
-                    rows={4}
-                    sx={{ p: 1 }}
-                    value={content}
-                    onChange={event => setContent(event.target.value)}
-                />
+                    <Stack>
+                        {meetings.map((meeting, index) => {
+                            return (
+                                <InputGroup
+                                    setMeetings={setMeetings}
+                                    meeting={meeting}
+                                    index={index}
+                                />
+                            )
+                        })}
+                        
+                        {/* addMeeting */}
+                        <button>Add Meeting Time</button>
 
-                {/*FIXME: Button href is wrong with new paradigm
-                    Not too sure where to redirect
-                */}
-                <Button href="/reflections" variant="contained" onClick={e => postData()}>Post</Button>
-            </Stack>
+                        {/* saveMeeting */}
+                        <Link to={`/orgs/${orgid}/teams/${teamid}/teambase`}>
+                            <button onClick={e => console.log("post and go back")}>Save</button>
+                        </Link>
+                    </Stack>
+                </div>
+            )}
         </div>
     )
 }

--- a/src/components/teambase/MeetingCard.js
+++ b/src/components/teambase/MeetingCard.js
@@ -4,7 +4,7 @@ import Box from '@mui/material/Box';
 export default function MeetingCard({ meeting }) {
     const convertTime = (time) => {
         const hour = Math.trunc(time);
-        let minute = (time % 1) * 60;
+        let minute = Math.trunc((time % 1) * 60);
         minute = minute < 10 ? `0${minute}` : minute;
         return `${hour}:${minute}`;
     }

--- a/src/components/teambase/MeetingCard.js
+++ b/src/components/teambase/MeetingCard.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+
+export default function MeetingCard({ meeting }) {
+    console.log(meeting);
+    return (
+        <Box
+            sx={{
+                bgcolor: 'white',
+                borderRadius: 8,
+                minWidth: 'auto',
+                minHeight: 196,
+                pt: 0.5,
+                pl: 4,
+                pr: 4,
+                pb: 0.5,
+                mb: 2
+            }}
+        >
+            <h2>{meeting.name}</h2>
+            <p>{`${meeting.start} ~ ${meeting.end}`}</p>
+            <p>{meeting.weekday}</p>
+        </Box>
+    );
+}

--- a/src/components/teambase/MeetingCard.js
+++ b/src/components/teambase/MeetingCard.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Box from '@mui/material/Box';
+import './Meeting.css';
 
 export default function MeetingCard({ meeting }) {
     const convertTime = (time) => {
@@ -16,22 +16,10 @@ export default function MeetingCard({ meeting }) {
     }
 
     return (
-        <Box
-            sx={{
-                bgcolor: 'white',
-                borderRadius: 8,
-                minWidth: 'auto',
-                minHeight: 196,
-                pt: 0.5,
-                pl: 4,
-                pr: 4,
-                pb: 0.5,
-                mb: 2
-            }}
-        >
-            <h2>{meeting.name}</h2>
-            <p>{`${convertTime(meeting.start)} ~ ${convertTime(meeting.end)}`}</p>
-            <p>{convertDay(meeting.weekday)}</p>
-        </Box>
+        <div className="meeting-card">
+            <h2 className="card-name">{meeting.name}</h2>
+            <p className="card-field">{`${convertTime(meeting.start)} ~ ${convertTime(meeting.end)}`}</p>
+            <p className="card-field">{convertDay(meeting.weekday)}</p>
+        </div>
     );
 }

--- a/src/components/teambase/MeetingCard.js
+++ b/src/components/teambase/MeetingCard.js
@@ -2,7 +2,19 @@ import React from 'react';
 import Box from '@mui/material/Box';
 
 export default function MeetingCard({ meeting }) {
-    console.log(meeting);
+    const convertTime = (time) => {
+        const hour = Math.trunc(time);
+        let minute = (time % 1) * 60;
+        minute = minute < 10 ? `0${minute}` : minute;
+        return `${hour}:${minute}`;
+    }
+
+    const convertDay = (day) => {
+        if (day > 7 && day < 0) return;
+        const days = ["Mondays", "Tuesdays", "Wednesdays", "Thursdays", "Fridays", "Saturdays", "Sundays"];
+        return days[day];
+    }
+
     return (
         <Box
             sx={{
@@ -18,8 +30,8 @@ export default function MeetingCard({ meeting }) {
             }}
         >
             <h2>{meeting.name}</h2>
-            <p>{`${meeting.start} ~ ${meeting.end}`}</p>
-            <p>{meeting.weekday}</p>
+            <p>{`${convertTime(meeting.start)} ~ ${convertTime(meeting.end)}`}</p>
+            <p>{convertDay(meeting.weekday)}</p>
         </Box>
     );
 }

--- a/src/components/teambase/MeetingsInputGroup.js
+++ b/src/components/teambase/MeetingsInputGroup.js
@@ -88,7 +88,8 @@ export default function InputGroup({ meetings, setMeetings, meeting, index }) {
                     type="text" 
                     name="name" 
                     value={name} 
-                    size="50" 
+                    size="50"
+                    placeholder='Meeting Name'
                     onChange={handleName}
                 />
                 
@@ -123,9 +124,9 @@ export default function InputGroup({ meetings, setMeetings, meeting, index }) {
                 
                 <div className='inline-div'>
                     <Clock size={24} />
-                    <input className="input-time" value={start < 0 ? 0 : start} onChange={handleStart} />
+                    <input className="input-time" placeholder="Start" value={start < 0 ? 0 : start} onChange={handleStart} />
                     <p> - </p>
-                    <input className="input-time" value={end < 0 ? 0 : end} onChange={handleEnd} />
+                    <input className="input-time" placeholder="End" value={end < 0 ? 0 : end} onChange={handleEnd} />
                 </div>
             </Stack>
         </div>

--- a/src/pages/PostCreation.js
+++ b/src/pages/PostCreation.js
@@ -23,6 +23,7 @@ export default function PostCreation() {
         setDate(new Date());
         const post = { title, content, date };
         fetch(`http://localhost:3000/api/board/${orgid}/${teamid}`, {
+            credentials: 'include',
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'

--- a/src/pages/Reflections.js
+++ b/src/pages/Reflections.js
@@ -11,7 +11,9 @@ export default function Reflections() {
     const [posts, setPosts] = React.useState([]);
 
     const loadPosts = async () => {
-        await fetch(`http://localhost:3000/api/board/${orgid}/${teamid}`)
+        await fetch(`http://localhost:3000/api/board/${orgid}/${teamid}`, {
+                credentials: 'include'
+            })
             .then(res => res.json())
             .then(receivedPosts => {
                 setPosts(receivedPosts);

--- a/src/pages/Tasks.js
+++ b/src/pages/Tasks.js
@@ -15,7 +15,9 @@ export default function Tasks() {
     const { orgid, teamid } = useParams();
 
     const loadAssignments = async () => {
-        await fetch(`http://localhost:3000/api/assignments/${orgid}/team/${teamid}`)
+        await fetch(`http://localhost:3000/api/assignments/${orgid}/team/${teamid}`, {
+                credentials: 'include'
+            })
             .then(res => res.json())
             .then(receivedData => {
                 setData(receivedData);

--- a/src/pages/Teambase.css
+++ b/src/pages/Teambase.css
@@ -1,8 +1,11 @@
-.container {
-    /* position: relative; */
-    /* width: 500px;
-    height: 500px;
-    background-color: #ffbf00; */
+.profile-container {
+    display: flex;
+    justify-content: space-evenly;
+}
+
+.profile-item {
+    color: #4B369D;
+    text-align: center;
 }
 
 .btn-add {

--- a/src/pages/Teambase.css
+++ b/src/pages/Teambase.css
@@ -24,8 +24,12 @@ h3 {
     margin-bottom: 13px;
 }
 
-.rows .row {
-    /* TODO: align section-title and btn-edit correctly */
-    display: inline-block;
-    justify-content: space-evenly;
+.section-break {
+    display: flex;
+    justify-content: space-between;
+}
+
+.btn-edit {
+    margin-top: 15px;
+    margin-right: 20px;
 }

--- a/src/pages/Teambase.css
+++ b/src/pages/Teambase.css
@@ -8,10 +8,12 @@
 .btn-add {
     margin: auto;
     border: 1px dashed #4B369D ;
+    border-radius: 15px;
     width: 342.9px;
-    height: 55.8px;
+    height: 53px;
     text-align: center;
     padding-top: 12px;
+    margin-top: 24px;
 }
 
 h3 {

--- a/src/pages/Teambase.css
+++ b/src/pages/Teambase.css
@@ -17,3 +17,9 @@
 h3 {
     /* font, font-size, font-family, padding-bottom, */
 }
+
+.rows .row {
+    /* TODO: align section-title and btn-edit correctly */
+    display: inline-block;
+    justify-content: space-evenly;
+ }

--- a/src/pages/Teambase.css
+++ b/src/pages/Teambase.css
@@ -16,10 +16,14 @@
 
 h3 {
     /* font, font-size, font-family, padding-bottom, */
+    color: #4B369D;
+    padding-left: 27px;
+    font-family: 'Poppins';
+    margin-bottom: 13px;
 }
 
 .rows .row {
     /* TODO: align section-title and btn-edit correctly */
     display: inline-block;
     justify-content: space-evenly;
- }
+}

--- a/src/pages/Teambase.js
+++ b/src/pages/Teambase.js
@@ -4,14 +4,16 @@ import HeaderBar from '../components/nav/HeaderBar';
 import BottomNavBar from '../components/nav/BottomNavbar';
 import { Divider } from '@mui/material';
 import { Plus, PencilSimple } from "phosphor-react";
-import './Teambase.css'
 import MeetingCard from '../components/teambase/MeetingCard';
 import GoalCard from '../components/teambase/GoalCard';
 import EmailCard from '../components/teambase/EmailCard';
+import './Teambase.css'
 
 export default function Teambase() {
     const { orgid, teamid } = useParams();
     const meetingPath = `/orgs/${orgid}/teams/${teamid}/teambase/meetings`;
+    const goalPath = `/orgs/${orgid}/teams/${teamid}/teambase/goals`;
+    const emailPath = `/orgs/${orgid}/teams/${teamid}/teambase/emails`;
 
     const [isLoaded, setIsLoaded] = React.useState(false);
     const [meetings, setMeetings] = React.useState([]);
@@ -63,7 +65,12 @@ export default function Teambase() {
                         </div>
                     )}
                     
-                    <h3>Team Goals</h3>
+                    <div className='section-break'>
+                        <h3>Team Goals</h3>
+                        {meetings.length > 0 && (
+                            <Link className="btn-edit" to={goalPath}><PencilSimple size={30} color='#4B369D' /></Link>
+                        )}
+                    </div>
                     <Divider/>
                     {goals.length < 1 ? (
                         <Link to={meetingPath}>
@@ -77,10 +84,15 @@ export default function Teambase() {
                         </div>
                     )}
 
-                    <h3>Emails</h3>
+                    <div className='section-break'>
+                        <h3>Emails</h3>
+                        {meetings.length > 0 && (
+                            <Link className="btn-edit" to={emailPath}><PencilSimple size={30} color='#4B369D' /></Link>
+                        )}
+                    </div>
                     <Divider/>
                     {profiles.length < 1 ? (
-                        <Link to={meetingPath}>
+                        <Link to={emailPath}>
                             <div className="btn-add">
                                 <Plus size={24} color="#4B369D"/>
                             </div>

--- a/src/pages/Teambase.js
+++ b/src/pages/Teambase.js
@@ -7,6 +7,7 @@ import { Plus } from "phosphor-react";
 import './Teambase.css'
 import MeetingCard from '../components/teambase/MeetingCard';
 import GoalCard from '../components/teambase/GoalCard';
+import EmailCard from '../components/teambase/EmailCard';
 
 export default function Teambase() {
     const { orgid, teamid } = useParams();
@@ -79,6 +80,17 @@ export default function Teambase() {
 
                     <h3>Emails</h3>
                     <Divider/>
+                    {profiles.length < 1 ? (
+                        <Link to={meetingPath}>
+                            <div className="btn-add">
+                                <Plus size={24} color="#4B369D"/>
+                            </div>
+                        </Link>
+                    ) : (
+                        <div className='meeting-list'>
+                            {profiles.map(contact => <EmailCard contact={contact}/>)}
+                        </div>
+                    )}
 
                     <BottomNavBar />
                 </div>

--- a/src/pages/Teambase.js
+++ b/src/pages/Teambase.js
@@ -45,7 +45,9 @@ export default function Teambase() {
                 <div>
                     <div className='rows'>
                         <h3 className='row'>Meeting Times</h3>
-                        {meetings.length > 0 && (<button className='row'>Edit</button>)}
+                        {meetings.length > 0 && (
+                            <Link to={meetingPath}><button className='row'>Edit</button></Link>
+                        )}
                     </div>
                     <Divider/>
                     {meetings.length < 1 ? (

--- a/src/pages/Teambase.js
+++ b/src/pages/Teambase.js
@@ -21,7 +21,9 @@ export default function Teambase() {
     const [goals, setGoals] = React.useState([]);
 
     const loadCharters = async () => {
-        await fetch(`http://localhost:3000/api/charters/${orgid}/${teamid}`)
+        await fetch(`http://localhost:3000/api/charters/${orgid}/${teamid}`, {
+                credentials: 'include'
+            })
             .then(res => res.json())
             .then(receivedPosts => {
                 receivedPosts.data.forEach(data => {

--- a/src/pages/Teambase.js
+++ b/src/pages/Teambase.js
@@ -7,10 +7,6 @@ import { Plus } from "phosphor-react";
 import './Teambase.css'
 import MeetingCard from '../components/teambase/MeetingCard';
 
-const domain = "localhost:3000";
-const orgid = "6263d2fb17033b23e05c0401";
-const teamid = "1";
-
 export default function Teambase() {
     const { orgid, teamid } = useParams();
     const meetingPath = `/orgs/${orgid}/teams/${teamid}/teambase/meetings`;
@@ -21,7 +17,7 @@ export default function Teambase() {
     const [goals, setGoals] = React.useState([]);
 
     const loadPosts = async () => {
-        await fetch(`http://${domain}/api/charters/${orgid}/${teamid}`)
+        await fetch(`http://localhost:3000/api/charters/${orgid}/${teamid}`)
             .then(res => res.json())
             .then(receivedPosts => {
                 receivedPosts.data.forEach(data => {

--- a/src/pages/Teambase.js
+++ b/src/pages/Teambase.js
@@ -3,7 +3,7 @@ import { Link, useParams } from 'react-router-dom';
 import HeaderBar from '../components/nav/HeaderBar';
 import BottomNavBar from '../components/nav/BottomNavbar';
 import { Divider } from '@mui/material';
-import { Plus } from "phosphor-react";
+import { Plus, PencilSimple } from "phosphor-react";
 import './Teambase.css'
 import MeetingCard from '../components/teambase/MeetingCard';
 import GoalCard from '../components/teambase/GoalCard';
@@ -18,7 +18,7 @@ export default function Teambase() {
     const [profiles, setProfiles] = React.useState([]);
     const [goals, setGoals] = React.useState([]);
 
-    const loadPosts = async () => {
+    const loadCharters = async () => {
         await fetch(`http://localhost:3000/api/charters/${orgid}/${teamid}`)
             .then(res => res.json())
             .then(receivedPosts => {
@@ -35,8 +35,7 @@ export default function Teambase() {
             })
     }
     React.useEffect(() => {
-        // fetch meeting times from api
-        loadPosts();
+        loadCharters();
     }, []);
 
     return (
@@ -45,10 +44,10 @@ export default function Teambase() {
             {!isLoaded && <p>Loading...</p>}
             {isLoaded && (
                 <div>
-                    <div className='rows'>
-                        <h3 className='row'>Meeting Times</h3>
+                    <div className='section-break'>
+                        <h3>Meeting Times</h3>
                         {meetings.length > 0 && (
-                            <Link to={meetingPath}><button className='row'>Edit</button></Link>
+                            <Link className="btn-edit" to={meetingPath}><PencilSimple size={30} color='#4B369D' /></Link>
                         )}
                     </div>
                     <Divider/>

--- a/src/pages/Teambase.js
+++ b/src/pages/Teambase.js
@@ -3,7 +3,7 @@ import { Link, useParams } from 'react-router-dom';
 import HeaderBar from '../components/nav/HeaderBar';
 import BottomNavBar from '../components/nav/BottomNavbar';
 import { Divider } from '@mui/material';
-import { Plus, PencilSimple } from "phosphor-react";
+import { Plus, PencilSimple, User } from "phosphor-react";
 import MeetingCard from '../components/teambase/MeetingCard';
 import GoalCard from '../components/teambase/GoalCard';
 import EmailCard from '../components/teambase/EmailCard';
@@ -46,6 +46,18 @@ export default function Teambase() {
             {!isLoaded && <p>Loading...</p>}
             {isLoaded && (
                 <div>
+                    <div className='profile-container'>
+                        {profiles.map((profile, i) => {
+                            return (
+                                <div key={`profile-item-${i}`} className='profile-item'>
+                                    {/* TODO: face-man-profile icon */}
+                                    <User size={70} color="#4B369D" />
+                                    <p>{profile.name}</p>
+                                </div>
+                            )
+                        })}
+                    </div>
+
                     <div className='section-break'>
                         <h3>Meeting Times</h3>
                         {meetings.length > 0 && (

--- a/src/pages/Teambase.js
+++ b/src/pages/Teambase.js
@@ -5,34 +5,73 @@ import BottomNavBar from '../components/nav/BottomNavbar';
 import { Divider } from '@mui/material';
 import { Plus } from "phosphor-react";
 import './Teambase.css'
+import MeetingCard from '../components/teambase/MeetingCard';
+
+const domain = "localhost:3000";
+const orgid = "6263d2fb17033b23e05c0401";
+const teamid = "1";
 
 export default function Teambase() {
     const meetingPath = "/teambase/meetings";
 
+    const [isLoaded, setIsLoaded] = React.useState(false);
+    const [meetings, setMeetings] = React.useState([]);
+    const [profiles, setProfiles] = React.useState([]);
+    const [goals, setGoals] = React.useState([]);
+
+    const loadPosts = async () => {
+        await fetch(`http://${domain}/api/charters/${orgid}/${teamid}`)
+            .then(res => res.json())
+            .then(receivedPosts => {
+                receivedPosts.data.forEach(data => {
+                    if (data.meetingTimes) setMeetings(data.meetingTimes)
+                    else if (data.profile) setProfiles(data.profile)
+                    else if (data.goals) setGoals(data.goals)
+                })
+                setIsLoaded(true);
+            })
+            .catch(error => {
+                setIsLoaded(false);
+                console.log("load data error:", error);
+            })
+    }
+    React.useEffect(() => {
+        // fetch meeting times from api
+        loadPosts();
+    }, []);
+
     return (
         <div className='container'>
             <HeaderBar screenname="TeamBase" />
-            
-            <div>
-                <h3>Meeting Times</h3>
-                <Divider/>
-                <Link to={meetingPath}>
-                    <div
-                        className="btn-add"
-                        onClick={(e) => console.log("clicked")}
-                    >
-                        <Plus size={24} color="#4B369D"/>
+            {!isLoaded && <p>Loading...</p>}
+            {isLoaded && (
+                <div>
+                    <div className='rows'>
+                        <h3 className='row'>Meeting Times</h3>
+                        {meetings.length > 0 && (<button className='row'>Edit</button>)}
                     </div>
-                </Link>
-            </div>
-            
-            <h3>Team Goals</h3>
-            <Divider/>
+                    <Divider/>
+                    {meetings.length < 1 ? (
+                        <Link to={meetingPath}>
+                            <div className="btn-add">
+                                <Plus size={24} color="#4B369D"/>
+                            </div>
+                        </Link>
+                    ) : (
+                        <div className='meeting-list'>
+                            {meetings.map(meeting => <MeetingCard meeting={meeting}/>)}
+                        </div>
+                    )}
+                    
+                    <h3>Team Goals</h3>
+                    <Divider/>
 
-            <h3>Emails</h3>
-            <Divider/>
+                    <h3>Emails</h3>
+                    <Divider/>
 
-            <BottomNavBar />
+                    <BottomNavBar />
+                </div>
+            )}
         </div>
     )
 }

--- a/src/pages/Teambase.js
+++ b/src/pages/Teambase.js
@@ -35,7 +35,7 @@ export default function Teambase() {
     React.useEffect(() => {
         // fetch meeting times from api
         loadPosts();
-    }, [meetings]); /** TODO: handle profiles and goals */
+    }, []);
 
     return (
         <div className='container'>

--- a/src/pages/Teambase.js
+++ b/src/pages/Teambase.js
@@ -6,6 +6,7 @@ import { Divider } from '@mui/material';
 import { Plus } from "phosphor-react";
 import './Teambase.css'
 import MeetingCard from '../components/teambase/MeetingCard';
+import GoalCard from '../components/teambase/GoalCard';
 
 export default function Teambase() {
     const { orgid, teamid } = useParams();
@@ -64,6 +65,17 @@ export default function Teambase() {
                     
                     <h3>Team Goals</h3>
                     <Divider/>
+                    {goals.length < 1 ? (
+                        <Link to={meetingPath}>
+                            <div className="btn-add">
+                                <Plus size={24} color="#4B369D"/>
+                            </div>
+                        </Link>
+                    ) : (
+                        <div className='meeting-list'>
+                            {goals.map(goal => <GoalCard goal={goal}/>)}
+                        </div>
+                    )}
 
                     <h3>Emails</h3>
                     <Divider/>

--- a/src/pages/Teambase.js
+++ b/src/pages/Teambase.js
@@ -35,7 +35,7 @@ export default function Teambase() {
     React.useEffect(() => {
         // fetch meeting times from api
         loadPosts();
-    }, []);
+    }, [meetings]); /** TODO: handle profiles and goals */
 
     return (
         <div className='container'>

--- a/src/pages/TodoCreation.js
+++ b/src/pages/TodoCreation.js
@@ -50,7 +50,9 @@ export default function TodoCreation() {
 
     // get assignment list from api : names & due dates
     const loadAssignments = async () => {
-        await fetch("http://localhost:3000/api/assignments/6263d2fb17033b23e05c0401/team/1")
+        await fetch("http://localhost:3000/api/assignments/6263d2fb17033b23e05c0401/team/1", {
+                credentials: 'include'
+            })
             .then(res => res.json())
             .then(receivedData => {
                 setAssignments(receivedData);
@@ -64,7 +66,9 @@ export default function TodoCreation() {
 
     // get team member list from api : names
     const loadMembers = async () => {
-        await fetch("http://localhost:3000/api/org/6263d2fb17033b23e05c0401/team/1")
+        await fetch("http://localhost:3000/api/org/6263d2fb17033b23e05c0401/team/1", {
+                credentials: 'include'
+            })
             .then(res => res.json())
             .then(receivedData => {
                 setMembers(receivedData.teams[0].members);
@@ -80,6 +84,7 @@ export default function TodoCreation() {
     const postTodo = () => {
         const todo = { content: todo_content, date: todo_due, assignedId: assignee.id, assignedName: assignee.name };
         fetch(`http://localhost:3000/api/assignments/6263d2fb17033b23e05c0401/${selected_assignment.id}/team/1`, {
+            credentials: 'include',
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'


### PR DESCRIPTION
Done
- Refactor HeaderBar and HeaderBarBackArrow
- Display meeting with cards
- Show/hide add/edit based on filled or not
- Add/edit meeting, goal, and email page
- Display team members with icon
- Fetch with user credentials (all)

Next
- Fix clicking elsewhere that doesn't change weekday selection
- Refactor add/edit screens using `Context` rather than `prop` to fix route to reload after modifying `InputGroup`